### PR TITLE
multiline as string array support

### DIFF
--- a/src/lib/entry.ts
+++ b/src/lib/entry.ts
@@ -6,7 +6,7 @@ export interface Entry {
 	word: string
 	class: string | string[]
 	pronounciation: Pronounciation
-	forms?: string
+	forms?: string | string[]
 	etymology: string | string[]
 	definitions: (Definition | TopDefinition)[]
 }

--- a/src/lib/entry.ts
+++ b/src/lib/entry.ts
@@ -7,7 +7,7 @@ export interface Entry {
 	class: string | string[]
 	pronounciation: Pronounciation
 	forms?: string
-	etymology: string
+	etymology: string | string[]
 	definitions: (Definition | TopDefinition)[]
 }
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -2,7 +2,7 @@ import { marked } from "marked"
 import type { smallMeta } from "./entry"
 import slugify from "@sindresorhus/slugify"
 
-export let markdown: ( md: string, inline?: boolean ) => string
+export let inlineMarkdown: ( md: string ) => string
 
 export function initMark ( allMeta: smallMeta[] ) {
 	const markedExtensions: marked.TokenizerAndRendererExtension[] = [
@@ -74,8 +74,8 @@ export function initMark ( allMeta: smallMeta[] ) {
 
 	marked.use({ extensions: markedExtensions, renderer })
 
-	markdown = function ( md: string, inline: boolean = true ): string {
-		return inline ? marked.parseInline(md) : marked.parse(md)
+	inlineMarkdown = function ( md: string ): string {
+		return marked.parseInline(md)
 	}
 
 	return function ( md: string, inline: boolean = true ): string {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -62,14 +62,16 @@ export function initMark ( allMeta: smallMeta[] ) {
 	const renderer = new marked.Renderer
 	renderer.link = ( href, title, text ) => {
 		if (href === null) {
-			return text;
+			return text
 		}
-		let out = "<a class=\"md-link\" href=\"" + href + "\"";
+	
+		let out = "<a class=\"md-link\" href=\"" + href + "\""
 		if (title) {
-			out += " title=\"" + title + "\"";
+			out += " title=\"" + title + "\""
 		}
-		out += ">" + text + "</a>";
-		return out;
+		out += ">" + text + "</a>"
+
+		return out
 	}
 
 	marked.use({ extensions: markedExtensions, renderer })

--- a/src/lib/view/definition.svelte
+++ b/src/lib/view/definition.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Entry } from "$lib/entry"
-	import { markdown } from "$lib/markdown"
+	import { inlineMarkdown } from "$lib/markdown"
 
 	export let definition: Entry["definitions"][0]
 	export let i: number
@@ -14,7 +14,7 @@
 
 <div class="def">
 	<span class="text">
-		<strong>{ind}.</strong> {#if definition.text}{@html markdown(definition.text)}{/if}
+		<strong>{ind}.</strong> {#if definition.text}{@html inlineMarkdown(definition.text)}{/if}
 	</span>
 	<Quotes quotes={definition.quotes} />
 </div>

--- a/src/lib/view/multitext.svelte
+++ b/src/lib/view/multitext.svelte
@@ -5,12 +5,23 @@
 </script>
 
 
-<!-- todo wait i think i can do this like inline? -->
+<div class="main">
+	{#if Array.isArray(text)}
+		{#each text as t}
+			<p>{@html inlineMarkdown(t)}</p>
+		{/each}
+	{:else}
+		<p>{@html inlineMarkdown(text)}</p>
+	{/if}
+</div>
 
-{#if Array.isArray(text)}
-	{#each text as t}
-		<p>{@html inlineMarkdown(t)}</p>
-	{/each}
-{:else}
-	{@html inlineMarkdown(text)}
-{/if}
+
+<style>
+	.main {
+		display: inline;
+	}
+
+	.main > p:first-child {
+		display: inline;
+	}
+</style>

--- a/src/lib/view/multitext.svelte
+++ b/src/lib/view/multitext.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { inlineMarkdown } from "$lib/markdown";
+
+	export let text: string | string[]
+</script>
+
+
+<!-- todo wait i think i can do this like inline? -->
+
+{#if Array.isArray(text)}
+	{#each text as t}
+		<p>{@html inlineMarkdown(t)}</p>
+	{/each}
+{:else}
+	{@html inlineMarkdown(text)}
+{/if}

--- a/src/lib/view/multitext.svelte
+++ b/src/lib/view/multitext.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { inlineMarkdown } from "$lib/markdown";
+    import { inlineMarkdown } from "$lib/markdown"
 
 	export let text: string | string[]
 </script>

--- a/src/lib/view/quote.svelte
+++ b/src/lib/view/quote.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Quote } from "$lib/entry"
-	import { markdown } from "$lib/markdown"
+	import { inlineMarkdown } from "$lib/markdown"
 
 	export let quotes: Quote[] | undefined
 </script>
@@ -14,9 +14,9 @@
 				<span class="d">{quote.date}</span>,
 				<span>'{quote.author}'</span>,
 				<span>{quote.location}</span>:
-				"{@html markdown(quote.text)}"
+				"{@html inlineMarkdown(quote.text)}"
 				{#if quote.note}
-					<div class="note">{@html markdown(quote.note)}</div>
+					<div class="note">{@html inlineMarkdown(quote.note)}</div>
 				{/if}
 			</div>
 		{/each}

--- a/src/routes/view/[id=integer]/[name]/+page.svelte
+++ b/src/routes/view/[id=integer]/[name]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PageData } from "./$types"
-	import { initMark, wordClassToString, markdown } from "$lib/markdown"
+	import { initMark, wordClassToString, inlineMarkdown } from "$lib/markdown"
 	import Definitions from "$lib/view/definitions.svelte"
     import Wrap from "$lib/view/wrap.svelte"
 
@@ -29,7 +29,7 @@
 				R.P. <code class="IPA">{entry.pronounciation.rp}</code>,
 				U.S. <code class="IPA">{entry.pronounciation.us}</code>
 				{#if entry.pronounciation.note}
-					{@html markdown(entry.pronounciation.note)}
+					{@html inlineMarkdown(entry.pronounciation.note)}
 				{/if}
 			</span>
 		</div>
@@ -37,13 +37,13 @@
 		<div class="view-item">
 			{#if entry.forms}
 				<span class="h">Forms:</span>
-				<span>{@html markdown(entry.forms)}</span>
+				<span>{@html inlineMarkdown(entry.forms)}</span>
 			{/if}
 		</div>
 
 		<div class="view-item">
 			<span class="h">Etymology:</span>
-			{@html markdown(entry.etymology, false)}
+			{@html inlineMarkdown(entry.etymology)}
 		</div>
 
 		<Definitions definitions={entry.definitions} />

--- a/src/routes/view/[id=integer]/[name]/+page.svelte
+++ b/src/routes/view/[id=integer]/[name]/+page.svelte
@@ -3,6 +3,7 @@
 	import { initMark, wordClassToString, inlineMarkdown } from "$lib/markdown"
 	import Definitions from "$lib/view/definitions.svelte"
     import Wrap from "$lib/view/wrap.svelte"
+    import Multitext from "$lib/view/multitext.svelte"
 
 	export let data: PageData
 	$: entry = data.entry
@@ -43,7 +44,10 @@
 
 		<div class="view-item">
 			<span class="h">Etymology:</span>
-			{@html inlineMarkdown(entry.etymology)}
+			<!-- {@html inlineMarkdown(entry.etymology)} -->
+			<div>
+				<Multitext text={entry.etymology} />
+			</div>
 		</div>
 
 		<Definitions definitions={entry.definitions} />

--- a/src/routes/view/[id=integer]/[name]/+page.svelte
+++ b/src/routes/view/[id=integer]/[name]/+page.svelte
@@ -38,16 +38,13 @@
 		<div class="view-item">
 			{#if entry.forms}
 				<span class="h">Forms:</span>
-				<span>{@html inlineMarkdown(entry.forms)}</span>
+				<Multitext text={entry.forms} />
 			{/if}
 		</div>
 
 		<div class="view-item">
 			<span class="h">Etymology:</span>
-			<!-- {@html inlineMarkdown(entry.etymology)} -->
-			<div>
-				<Multitext text={entry.etymology} />
-			</div>
+			<Multitext text={entry.etymology} />
 		</div>
 
 		<Definitions definitions={entry.definitions} />


### PR DESCRIPTION
add support to make multiline text line-per-line as a string array.

currently works for fields:  
`[entry].etymology`  
`[entry].forms`

also makes the first line be inline with the headline